### PR TITLE
Update invoice labels

### DIFF
--- a/config/locales/de/credit_note.yml
+++ b/config/locales/de/credit_note.yml
@@ -11,7 +11,7 @@ de:
     credited_refunded_notice: Auf Kundenguthaben gutgeschrieben und zurückerstattet am %{issuing_date}
     document_name: Gutschrift
     invoice_number: Rechnungsnummer
-    issue_date: Ausgabedatum
+    issue_date: Rechnungsdatum
     item: Artikel
     powered_by: Bereitgestellt von
     prepaid_credits_for_wallet: Prepaid-Guthaben - %{wallet_name}

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -42,7 +42,7 @@ de:
       flat_fee_for_the_next: Pauschalgebühr für die nächsten %{from} bis %{to}
     iban: IBAN
     invoice_number: Rechnungsnummer
-    issue_date: Ausgabedatum
+    issue_date: Rechnungsdatum
     item: Artikel
     list_of_charges: Liste der Gebühren vom %{from} bis %{to}
     month: monat
@@ -86,7 +86,7 @@ de:
     subscription_interval: "%{plan_interval}es Abonnement - %{plan_name}"
     swift_code: SWIFT-Code
     tax: Steuern
-    tax_identification_number: 'Steuer ID: %{tax_identification_number}'
+    tax_identification_number: 'USt-ID: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% on %{amount})"
     tax_name_only:
       customer_exempt: Der Kunde ist von der Umsatzsteuer befreit

--- a/config/locales/en/credit_note.yml
+++ b/config/locales/en/credit_note.yml
@@ -11,7 +11,7 @@ en:
     credited_refunded_notice: Credited on customer balance and refunded on %{issuing_date}
     document_name: Credit note
     invoice_number: Invoice number
-    issue_date: Issue date
+    issue_date: Invoice Date
     item: Item
     powered_by: Powered by
     prepaid_credits_for_wallet: Prepaid credits - %{wallet_name}

--- a/config/locales/en/email.yml
+++ b/config/locales/en/email.yml
@@ -31,7 +31,7 @@ en:
         credited_refunded_notice: Credited on customer balance and refunded on %{date}
         download: Download credit note for details
         invoice_number: Invoice number
-        issue_date: Issue date
+        issue_date: Invoice Date
         refunded_notice: Refunded on %{date}
         subject: 'Your credit note from %{billing_entity_name} #%{credit_note_number}'
     data_export:
@@ -49,7 +49,7 @@ en:
         due_date: total due %{date}
         invoice_from: Invoice from %{billing_entity_name}
         invoice_number: Invoice Number
-        issue_date: Issue Date
+        issue_date: Invoice Date
         issued_on: issued on %{date}
         subject: 'Your Invoice from %{billing_entity_name} #%{invoice_number}'
     password_reset:

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -43,7 +43,7 @@ en:
       flat_fee_for_the_next: Flat fee for the next %{from} to %{to}
     iban: IBAN
     invoice_number: Invoice Number
-    issue_date: Issue Date
+    issue_date: Invoice Date
     item: Item
     list_of_charges: List of charges used from %{from} to %{to}
     month: month
@@ -87,7 +87,7 @@ en:
     subscription_interval: "%{plan_interval} subscription - %{plan_name}"
     swift_code: SWIFT code
     tax: Tax
-    tax_identification_number: 'Tax ID: %{tax_identification_number}'
+    tax_identification_number: '(VAT-/Tax-)ID: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% on %{amount})"
     tax_name_only:
       customer_exempt: Customer is tax exempt


### PR DESCRIPTION
## Summary
- translate invoice dates to `Invoice Date`/`Rechnungsdatum`
- translate tax ID labels to `(VAT-/Tax-)ID`/`USt-ID`

## Testing
- `bundle exec rspec spec/i18n_spec.rb` *(fails: Could not find karafka-2.4.17, karafka-web-0.10.4, karafka-testing-2.4.6, karafka-core-2.4.8, karafka-rdkafka-0.17.6, waterdrop-2.7.4 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68592ff236ec8325b7bfca28979c4d78